### PR TITLE
Always return Query from Url::getQuery()

### DIFF
--- a/src/NormalisedUrl/Normaliser.php
+++ b/src/NormalisedUrl/Normaliser.php
@@ -106,8 +106,6 @@ class Normaliser extends Parser
 
     private function normaliseQuery()
     {
-        if (isset($this->parts[UrlInterface::PART_QUERY])) {
-            $this->parts[UrlInterface::PART_QUERY] = new Query\Query((string)$this->parts[UrlInterface::PART_QUERY]);
-        }
+        $this->parts[UrlInterface::PART_QUERY] = new Query\Query((string)$this->parts[UrlInterface::PART_QUERY]);
     }
 }

--- a/src/Url/Parser.php
+++ b/src/Url/Parser.php
@@ -56,9 +56,11 @@ class Parser implements ParserInterface
             $parts[UrlInterface::PART_FRAGMENT] = '';
         }
 
-        if (isset($parts[UrlInterface::PART_QUERY])) {
-            $parts[UrlInterface::PART_QUERY] = new Query($parts[UrlInterface::PART_QUERY]);
+        if (empty($parts[UrlInterface::PART_QUERY])) {
+            $parts[UrlInterface::PART_QUERY] = '';
         }
+
+        $parts[UrlInterface::PART_QUERY] = new Query($parts[UrlInterface::PART_QUERY]);
 
         if (isset($parts[UrlInterface::PART_PATH])) {
             $parts[UrlInterface::PART_PATH] = new Path($parts[UrlInterface::PART_PATH]);

--- a/src/Url/Query/Parser.php
+++ b/src/Url/Query/Parser.php
@@ -23,7 +23,7 @@ class Parser implements ParserInterface
      *
      * @param string $queryString
      */
-    public function __construct($queryString)
+    public function __construct($queryString = '')
     {
         $this->origin = $queryString;
         $this->parse();

--- a/src/Url/Query/Query.php
+++ b/src/Url/Query/Query.php
@@ -33,7 +33,7 @@ class Query
     /**
      * @param string $encodedQueryString
      */
-    public function __construct($encodedQueryString)
+    public function __construct($encodedQueryString = '')
     {
         $this->setOrigin($encodedQueryString);
         $this->parser = new Parser($this->origin);
@@ -163,5 +163,13 @@ class Query
     public function hasConfiguration()
     {
         return !is_null($this->configuration);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->pairs());
     }
 }

--- a/src/Url/Url.php
+++ b/src/Url/Url.php
@@ -58,8 +58,8 @@ class Url implements UrlInterface
      */
     public function __construct($originUrl = null)
     {
-        $this->init($originUrl);
         $this->configuration = new Configuration();
+        $this->init($originUrl);
     }
 
     /**
@@ -70,6 +70,10 @@ class Url implements UrlInterface
     {
         $this->originUrl = PreProcessor::preProcess($originUrl);
         $this->parts = $this->createParser()->getParts();
+
+        $query = $this->parts[UrlInterface::PART_QUERY];
+        $query->setConfiguration($this->configuration);
+        $this->parts[UrlInterface::PART_QUERY] = $query;
     }
 
     /**
@@ -327,11 +331,18 @@ class Url implements UrlInterface
     }
 
     /**
+     * @deprecated Deprecated since 1.9.15, to be removed in 2.0. Use $url->getQuery()->isEmpty() instead.
+     *
      * {@inheritdoc}
      */
     public function hasQuery()
     {
-        return $this->hasPart(UrlInterface::PART_QUERY);
+        @trigger_error(
+            'hasQuery() is deprecated since 1.9.15, to be removed in 2.0. ' .
+            'Use $url->getQuery()->isEmpty() instead.'
+        );
+
+        return true;
     }
 
     /**
@@ -339,12 +350,7 @@ class Url implements UrlInterface
      */
     public function getQuery()
     {
-        $query = $this->getPart(UrlInterface::PART_QUERY);
-        if ($query instanceof Query && !$query->hasConfiguration()) {
-            $query->setConfiguration($this->getConfiguration());
-        }
-
-        return $query;
+        return $this->getPart(UrlInterface::PART_QUERY);
     }
 
     /**
@@ -352,12 +358,6 @@ class Url implements UrlInterface
      */
     public function setQuery($query)
     {
-        if (is_null($query)) {
-            $this->removePart(UrlInterface::PART_QUERY);
-
-            return true;
-        }
-
         $query = trim($query);
 
         if ('?' === substr($query, 0, 1)) {
@@ -412,7 +412,8 @@ class Url implements UrlInterface
 
         $url .= $this->getPath();
 
-        if ($this->hasQuery()) {
+        $query = $this->getQuery();
+        if (!$query->isEmpty()) {
             $url .= '?' . $this->getQuery();
         }
 

--- a/tests/Url/ParserTest.php
+++ b/tests/Url/ParserTest.php
@@ -35,12 +35,14 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'url' => null,
                 'expectedParts' => [
                     UrlInterface::PART_PATH => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'empty' => [
                 'url' => '',
                 'expectedParts' => [
                     UrlInterface::PART_PATH => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'complete fully qualified' => [
@@ -88,6 +90,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'url' => '#',
                 'expectedParts' => [
                     UrlInterface::PART_FRAGMENT => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'path and hash only' => [
@@ -95,12 +98,14 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'expectedParts' => [
                     UrlInterface::PART_PATH => '/index.html',
                     UrlInterface::PART_FRAGMENT => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'hash and identifier only' => [
                 'url' => '#fragment',
                 'expectedParts' => [
                     UrlInterface::PART_FRAGMENT => 'fragment',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'scheme, no username, no password' => [
@@ -109,6 +114,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     UrlInterface::PART_SCHEME => 'https',
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'protocol-relative, no username, no password' => [
@@ -116,6 +122,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'expectedParts' => [
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'scheme, empty username, empty password' => [
@@ -125,6 +132,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => '',
                     UrlInterface::PART_PASS => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'protocol-relative, empty username, empty password' => [
@@ -133,6 +141,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => '',
                     UrlInterface::PART_PASS => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'scheme, empty username, has password' => [
@@ -142,6 +151,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => '',
                     UrlInterface::PART_PASS => 'password',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'protocol-relative, empty username, has password' => [
@@ -150,6 +160,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => '',
                     UrlInterface::PART_PASS => 'password',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'scheme, has username, empty password' => [
@@ -159,6 +170,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => 'username',
                     UrlInterface::PART_PASS => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'protocol-relative, has username, empty password' => [
@@ -167,6 +179,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => 'username',
                     UrlInterface::PART_PASS => '',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'scheme, has username, no password' => [
@@ -175,6 +188,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     UrlInterface::PART_SCHEME => 'https',
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => 'username',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
             'protocol-relative, has username, no password' => [
@@ -182,6 +196,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'expectedParts' => [
                     UrlInterface::PART_HOST => 'example.com',
                     UrlInterface::PART_USER => 'username',
+                    UrlInterface::PART_QUERY => '',
                 ],
             ],
         ];

--- a/tests/Url/Query/QueryTest.php
+++ b/tests/Url/Query/QueryTest.php
@@ -298,4 +298,12 @@ class QueryTest extends AbstractQueryTest
             ],
         ];
     }
+
+    public function testCreateEmptyQuery()
+    {
+        $query = new Query();
+
+        $this->assertEquals([], $query->pairs());
+        $this->assertEquals('', (string)$query);
+    }
 }

--- a/tests/Url/ScopeComparerTest.php
+++ b/tests/Url/ScopeComparerTest.php
@@ -47,8 +47,8 @@ class ScopeComparerTest extends \PHPUnit_Framework_TestCase
     {
         return [
             'two empty urls are in scope' => [
-                'sourceUrl' => new Url(''),
-                'comparatorUrl' => new Url(''),
+                'sourceUrl' => new Url(),
+                'comparatorUrl' => new Url(),
                 'equivalentSchemeSets' => [],
                 'equivalentHostSets' => [],
                 'expectedIsInScope' => true,

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -2,6 +2,7 @@
 
 namespace webignition\Tests\Url;
 
+use webignition\Url\Query\Query;
 use webignition\Url\Url;
 use webignition\Url\UrlInterface;
 
@@ -282,7 +283,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         return [
             'no query' => [
                 'url' => new Url('http://example.com'),
-                'expectedHasQuery' => false,
+                'expectedHasQuery' => true,
                 'expectedQuery' => '',
             ],
             'has query' => [
@@ -1216,7 +1217,11 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $url->setQuery(null);
 
         $this->assertNull($url->getFragment());
-        $this->assertNull($url->getQuery());
+
+        $query = $url->getQuery();
+
+        $this->assertInstanceOf(Query::class, $query);
+        $this->assertTrue($query->isEmpty());
 
         $this->assertEquals('http://example.com/', (string)$url);
     }
@@ -1249,6 +1254,41 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             'key only query' => [
                 'url' => new Url('?key'),
                 'expectedStringUrl' => '?key',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getQueryDataProvider
+     *
+     * @param Url $url
+     * @param string $expectedQueryString
+     * @param string $expectedUrl
+     */
+    public function testGetQuery(Url $url, $expectedQueryString, $expectedUrl)
+    {
+        $query = $url->getQuery();
+
+        $this->assertInstanceOf(Query::class, $url->getQuery());
+        $this->assertEquals($expectedQueryString, (string)$query);
+        $this->assertEquals($expectedUrl, (string)$url);
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryDataProvider()
+    {
+        return [
+            'no query' => [
+                'url' => new Url('//example.com'),
+                'expectedQueryString' => '',
+                'expectedUrl' => '//example.com',
+            ],
+            'has query' => [
+                'url' => new Url('//example.com?foo=bar'),
+                'expectedQueryString' => 'foo=bar',
+                'expectedUrl' => '//example.com?foo=bar',
             ],
         ];
     }


### PR DESCRIPTION
Always return a `Query` instance from `Url::getQuery()`;

It no longer makes sense to have `Url::hasQuery()` as this will always be true. This method has been deprecated and will be removed in 2.0. Use `Url::getQuery()::isEmpty()` instead.

Fixes https://github.com/webignition/url/issues/8