### PR TITLE
Mark package as abandoned with replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A PSR-7 `UriInterface` for modelling a URL and accessing/modifying components.
 A `Normalizer` for applying a range of semantically-lossless, potentially-lossless or lossy normalizations,
 most commonly for comparison.
 
+## Replaced!
+
+This package has been replaced by `webiginition/uri`. You should avoid using this in new projects, and migrate existing projects to the replacement.
+
 ## Requirements
 
 - PHP 7.2.0 or greater

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "homepage": "https://github.com/webignition/url",
     "type": "library",
     "license": "MIT",
+    "abandoned": "webignition/uri",
     "authors": [
         {
             "name": "Jon Cram",


### PR DESCRIPTION
As multiple issues have been redirected into the `webignition/uri` repository, it seems appropriate to include the same information into the package itself.

I'd also suggest updating the repository pins on your profile :)